### PR TITLE
feat: auto restart postgres-language-server after panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 out
 .env
 extension.vsix
+.DS_Store

--- a/src/session.ts
+++ b/src/session.ts
@@ -351,8 +351,8 @@ const createLanguageClient = (bin: Uri, projects: Project[]) => {
       closed: (): CloseHandlerResult | Promise<CloseHandlerResult> => {
         logger.error("Postgres Language Server language server closed");
         return {
-          action: CloseAction.DoNotRestart,
-          message: "Postgres Language Server language server closed",
+          action: CloseAction.Restart,
+          message: "Postgres Language Server language server is restarting",
         };
       },
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Implements feature #66 to improve developer experience when postgres-language-server panics (in rust).

## What is the current behavior?

The extension crashes when analysing incomplete join syntax - refer to https://github.com/supabase-community/postgres-language-server/issues/636

The language server, postgres-language-server, panics when treesitter fails to parse node. But the extension is configured to not reboot, requiring manual reboots - leading to poor developer experience since VSCode requires you to restart all extensions.

## What is the new behavior?

When the language server panics, the extension should reboot the server.